### PR TITLE
Support the force public flag and acl header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ interface IS3UserConfig {
   endpoint?: string
   urlPrefix?: string
   pathStyleAccess?: boolean
+  forcePublic?: boolean
 }
 
 export = (ctx: picgo) => {
@@ -84,6 +85,14 @@ export = (ctx: picgo) => {
         message: 'enable path-style-access or not',
         required: false,
         alias: 'PathStyleAccess'
+      },
+      {
+        name: 'forcePublic',
+        type: 'confirm',
+        default: userConfig.forcePublic || false,
+        message: '是否强制设置为公开',
+        required: false,
+        alias: 'ForcePublic'
       }
     ]
   }
@@ -113,7 +122,8 @@ export = (ctx: picgo) => {
         userConfig.bucketName,
         formatPath(item, userConfig.uploadPath),
         item,
-        idx
+        idx,
+        userConfig.forcePublic
       )
     )
 

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -31,7 +31,8 @@ function createUploadTask (
   bucketName: string,
   path: string,
   item: IImgInfo,
-  index: number
+  index: number,
+  forcePublic: boolean
 ): Promise<IUploadResult> {
   return new Promise(async (resolve, reject) => {
     if (!item.buffer && !item.base64Image) {
@@ -40,6 +41,9 @@ function createUploadTask (
     const opts: PutObjectRequest = {
       Key: path,
       Bucket: bucketName
+    }
+    if (forcePublic) {
+      opts.ACL = 'public-read'
     }
     if (item.buffer) {
       opts.Body = item.buffer


### PR DESCRIPTION
The default ACL is set to private in some S3 compatible services like DigitalOcean Spaces. The PR try to add an optional ACL header which can indicate that the file is public access so that the pictures can be reached by anyone.