### PR TITLE
Support custom S3 acl header.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ interface IS3UserConfig {
   endpoint?: string
   urlPrefix?: string
   pathStyleAccess?: boolean
+  acl: string
 }
 
 export = (ctx: picgo) => {
@@ -20,7 +21,8 @@ export = (ctx: picgo) => {
       secretAccessKey: '',
       bucketName: '',
       uploadPath: '{year}/{month}/{md5}.{extName}',
-      pathStyleAccess: false
+      pathStyleAccess: false,
+      acl: 'public-read'
     }
     let userConfig = ctx.getConfig<IS3UserConfig>('picBed.aws-s3')
     userConfig = { ...defaultConfig, ...(userConfig || {}) }
@@ -54,6 +56,14 @@ export = (ctx: picgo) => {
         default: userConfig.uploadPath,
         required: true,
         alias: '文件路径'
+      },
+      {
+        name: 'acl',
+        type: 'input',
+        default: userConfig.acl,
+        message: '文件访问权限',
+        required: true,
+        alias: '权限'
       },
       {
         name: 'region',
@@ -113,7 +123,8 @@ export = (ctx: picgo) => {
         userConfig.bucketName,
         formatPath(item, userConfig.uploadPath),
         item,
-        idx
+        idx,
+        userConfig.acl
       )
     )
 

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -31,7 +31,8 @@ function createUploadTask (
   bucketName: string,
   path: string,
   item: IImgInfo,
-  index: number
+  index: number,
+  acl: string
 ): Promise<IUploadResult> {
   return new Promise(async (resolve, reject) => {
     if (!item.buffer && !item.base64Image) {
@@ -39,7 +40,8 @@ function createUploadTask (
     }
     const opts: PutObjectRequest = {
       Key: path,
-      Bucket: bucketName
+      Bucket: bucketName,
+      ACL: acl
     }
     if (item.buffer) {
       opts.Body = item.buffer


### PR DESCRIPTION
The default ACL is set to private in some S3 compatible services like DigitalOcean Spaces. The PR try to add a required custom ACL header (default public-read) which can indicate that the file is public access so that the pictures can be reached by anyone.