### PR TITLE
增加关闭‘拒绝无效TLS证书连接’的设置

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ picgo set uploader aws-s3
 | `endpoint`        | 指定自定义终端节点            | `s3.us-west-2.amazonaws.com`       |
 | `region`          | 指定执行服务请求的区域        | `us-west-1`                        |
 | `pathStyleAccess` | 是否启用 S3 Path style | 默认为 `false`，使用 minio 请设置为 `true` |
+| `rejectUnauthorized` | 是否拒绝无效TLS证书连接 | 默认为 `true`，如上传失败日志显示证书问题可设置为`false`|
 | `acl` | 访问控制列表，上传资源的访问策略 | 默认为 `public-read` |
 
 **上传路径支持 payload：**

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ interface IS3UserConfig {
   endpoint?: string
   urlPrefix?: string
   pathStyleAccess?: boolean
+  rejectUnauthorized?:boolean
   acl?: string
 }
 
@@ -22,6 +23,7 @@ export = (ctx: picgo) => {
       bucketName: '',
       uploadPath: '{year}/{month}/{md5}.{extName}',
       pathStyleAccess: false,
+      rejectUnauthorized: true,
       acl: 'public-read'
     }
     let userConfig = ctx.getConfig<IS3UserConfig>('picBed.aws-s3')
@@ -96,6 +98,14 @@ export = (ctx: picgo) => {
         alias: 'PathStyleAccess'
       },
       {
+        name: 'rejectUnauthorized',
+        type: 'confirm',
+        default: userConfig.rejectUnauthorized || true,
+        message: 'enable path-style-access or not',
+        required: false,
+        alias: 'rejectUnauthorized'
+      },
+      {
         name: 'acl',
         type: 'input',
         default: userConfig.acl || 'public-read',
@@ -120,7 +130,8 @@ export = (ctx: picgo) => {
       userConfig.secretAccessKey,
       userConfig.region,
       userConfig.endpoint,
-      userConfig.pathStyleAccess
+      userConfig.pathStyleAccess,
+      userConfig.rejectUnauthorized
     )
 
     const output = ctx.output

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -2,6 +2,7 @@ import AWS from 'aws-sdk'
 import { PutObjectRequest } from 'aws-sdk/clients/s3'
 import { IImgInfo } from 'picgo/dist/src/types'
 import { extractInfo } from './utils'
+import https from 'https'
 
 export interface IUploadResult {
   url: string
@@ -14,8 +15,18 @@ function createS3Client(
   secretAccessKey: string,
   region: string,
   endpoint: string,
-  pathStyleAccess: boolean
+  pathStyleAccess: boolean,
+  rejectUnauthorized:boolean
 ): AWS.S3 {
+  if (!rejectUnauthorized) {
+    AWS.config.update({
+      httpOptions: {
+        agent: new https.Agent({
+          rejectUnauthorized: false,
+        })
+      }
+    });
+}
   const s3 = new AWS.S3({
     region,
     endpoint,


### PR DESCRIPTION
backblaze b2用的是Let's Encrypt的证书，有效期只有3个月，可能经常会出现过期情况。此外如果有人用自建服务或者测试的话，也可以顺便支持自签名证书。