### PR TITLE
Custom domain path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ picgo set uploader aws-s3
 | `rejectUnauthorized`       | 是否拒绝无效 TLS 证书连接                                  | 默认为 `true`，如上传失败日志显示证书问题可设置为`false`                                                                                                         |
 | `acl`                      | 访问控制列表，上传资源的访问策略                                 | 默认为 `public-read`, AWS 可选 `private"                                                                                                         |"public-read"|"public-read-write"|"authenticated-read"|"aws-exec-read"|"bucket-owner-read"|"bucket-owner-full-control`                                     |
 | `disableBucketPrefixToURL` | 开启 `pathStyleAccess` 时，是否要禁用最终生成 URL 中添加 bucket 前缀 | 默认为 `false`                                                                                                                                 |
+| `customImagePath`          | 自定义图片路径                                         | `{year}{month}/original/{md5}.{extName}`                                                                                                     |
 
 **上传路径支持 payload：**
 
@@ -64,7 +65,8 @@ picgo set uploader aws-s3
       "bucketName": "my-bucket",
       "uploadPath": "{year}/{md5}.{extName}",
       "endpoint": "s3.us-west-000.backblazeb2.com",
-      "urlPrefix": "https://img.example.com/"
+      "urlPrefix": "https://img.example.com/",
+      "customImagePath": "{year}{month}/original/{md5}.{extName}"
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ picgo set uploader aws-s3
 | `rejectUnauthorized`       | 是否拒绝无效 TLS 证书连接                                  | 默认为 `true`，如上传失败日志显示证书问题可设置为`false`                                                                                                         |
 | `acl`                      | 访问控制列表，上传资源的访问策略                                 | 默认为 `public-read`, AWS 可选 `private"                                                                                                         |"public-read"|"public-read-write"|"authenticated-read"|"aws-exec-read"|"bucket-owner-read"|"bucket-owner-full-control`                                     |
 | `disableBucketPrefixToURL` | 开启 `pathStyleAccess` 时，是否要禁用最终生成 URL 中添加 bucket 前缀 | 默认为 `false`                                                                                                                                 |
-| `customImagePath`          | 自定义图片路径                                         | `{year}{month}/original/{md5}.{extName}`                                                                                                     |
+| `urlPath`                  | 自定义图片路径                                         | `{year}{month}/original/{md5}.{extName}`                                                                                                     |
 
 **上传路径支持 payload：**
 
@@ -66,7 +66,7 @@ picgo set uploader aws-s3
       "uploadPath": "{year}/{md5}.{extName}",
       "endpoint": "s3.us-west-000.backblazeb2.com",
       "urlPrefix": "https://img.example.com/",
-      "customImagePath": "{year}{month}/original/{md5}.{extName}"
+      "urlPath": "{year}{month}/original/{md5}.{extName}"
     }
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,4 +12,5 @@ export interface IS3UserConfig {
   acl?: string
   disableBucketPrefixToURL?: boolean
   urlSuffix?: string
+  customImagePath?: string
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,5 +12,5 @@ export interface IS3UserConfig {
   acl?: string
   disableBucketPrefixToURL?: boolean
   urlSuffix?: string
-  customImagePath?: string
+  urlPath?: string
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,13 @@ export = (ctx: PicGo) => {
         alias: "设定网址后缀",
       },
       {
+        name: "customImagePath", // Added customImagePath configuration option
+        type: "input",
+        default: userConfig.customImagePath,
+        required: false,
+        alias: "自定义图片网址path",
+      },
+      {
         name: "pathStyleAccess",
         type: "confirm",
         default: userConfig.pathStyleAccess || false,
@@ -119,13 +126,6 @@ export = (ctx: PicGo) => {
           "开启 `pathStyleAccess` 时，是否要禁用最终生成URL中添加 bucket 前缀",
         required: false,
         alias: "Bucket 前缀",
-      },
-      {
-        name: "customImagePath", // Added customImagePath configuration option
-        type: "input",
-        default: userConfig.customImagePath,
-        required: false,
-        alias: "自定义图片路径",
       },
     ]
   }
@@ -178,7 +178,7 @@ export = (ctx: PicGo) => {
       delete output[index].buffer
       delete output[index].base64Image
       output[index].imgUrl = `${imgURL}${userConfig?.urlSuffix || ''}`
-      output[index].url = `${urlPrefix}/${formatPath(output[index], userConfig.customImagePath || userConfig.uploadPath)}${userConfig?.urlSuffix || ''}` // Use customImagePath for returned URL
+      output[index].url = `${url}${userConfig?.urlSuffix || ''}`
     }
 
     return ctx

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export = (ctx: PicGo) => {
       rejectUnauthorized: true,
       acl: "public-read",
       urlSuffix: "",
+      customImagePath: "", // Added customImagePath to defaultConfig
     }
     let userConfig = ctx.getConfig<IS3UserConfig>("picBed.aws-s3")
     userConfig = { ...defaultConfig, ...(userConfig || {}) }
@@ -119,6 +120,13 @@ export = (ctx: PicGo) => {
         required: false,
         alias: "Bucket 前缀",
       },
+      {
+        name: "customImagePath", // Added customImagePath configuration option
+        type: "input",
+        default: userConfig.customImagePath,
+        required: false,
+        alias: "自定义图片路径",
+      },
     ]
   }
 
@@ -143,7 +151,7 @@ export = (ctx: PicGo) => {
         client,
         index: idx,
         bucketName: userConfig.bucketName,
-        path: formatPath(item, userConfig.uploadPath),
+        path: formatPath(item, userConfig.uploadPath), // Use uploadPath for S3 upload
         item: item,
         acl: userConfig.acl,
         urlPrefix,
@@ -170,7 +178,7 @@ export = (ctx: PicGo) => {
       delete output[index].buffer
       delete output[index].base64Image
       output[index].imgUrl = `${imgURL}${userConfig?.urlSuffix || ''}`
-      output[index].url = `${url}${userConfig?.urlSuffix || ''}`
+      output[index].url = `${urlPrefix}/${formatPath(output[index], userConfig.customImagePath || userConfig.uploadPath)}${userConfig?.urlSuffix || ''}` // Use customImagePath for returned URL
     }
 
     return ctx

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export = (ctx: PicGo) => {
       rejectUnauthorized: true,
       acl: "public-read",
       urlSuffix: "",
-      customImagePath: "", // Added customImagePath to defaultConfig
+      urlPath: "", // Renamed customImagePath to urlPath in defaultConfig
     }
     let userConfig = ctx.getConfig<IS3UserConfig>("picBed.aws-s3")
     userConfig = { ...defaultConfig, ...(userConfig || {}) }
@@ -88,9 +88,9 @@ export = (ctx: PicGo) => {
         alias: "设定网址后缀",
       },
       {
-        name: "customImagePath", // Added customImagePath configuration option
+        name: "urlPath", // Renamed customImagePath to urlPath in configuration option
         type: "input",
-        default: userConfig.customImagePath,
+        default: userConfig.urlPath,
         required: false,
         alias: "自定义图片网址path",
       },

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -70,7 +70,7 @@ interface createUploadTaskOpts {
   index: number
   acl: string
   urlPrefix?: string
-  customImagePath?: string
+  urlPath?: string
 }
 
 async function createUploadTask(
@@ -116,7 +116,7 @@ async function createUploadTask(
       return Promise.reject(err)
     }
   } else {
-    url = `${opts.urlPrefix}/${opts.customImagePath ? formatPath(opts.item, opts.customImagePath) : opts.path}`
+    url = `${opts.urlPrefix}/${opts.urlPath ? formatPath(opts.item, opts.urlPath) : opts.path}`
   }
 
   return {

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -14,7 +14,7 @@ import {
 import url from "url"
 import { HttpProxyAgent, HttpsProxyAgent } from "hpagent"
 import { IImgInfo } from "picgo"
-import { extractInfo, getProxyAgent } from "./utils"
+import { extractInfo, getProxyAgent, formatPath } from "./utils"
 import { IS3UserConfig } from "./config"
 
 export interface IUploadResult {
@@ -70,6 +70,7 @@ interface createUploadTaskOpts {
   index: number
   acl: string
   urlPrefix?: string
+  customImagePath?: string
 }
 
 async function createUploadTask(
@@ -115,7 +116,7 @@ async function createUploadTask(
       return Promise.reject(err)
     }
   } else {
-    url = `${opts.urlPrefix}/${opts.path}`
+    url = `${opts.urlPrefix}/${opts.customImagePath ? formatPath(opts.item, opts.customImagePath) : opts.path}`
   }
 
   return {


### PR DESCRIPTION
issue:#45 

This pull request introduces a new feature for customizing the image URL path in the AWS S3 uploader configuration. The most important changes include updating the `README.md` file, modifying the configuration interface, and adjusting the implementation to support the new `urlPath` option.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37): Added a new `urlPath` option to the documentation for customizing the image path. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R69)

Configuration updates:

* [`src/config.ts`](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R15): Added `urlPath` to the `IS3UserConfig` interface.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R17): Updated the default configuration and user configuration to include `urlPath`. Renamed `customImagePath` to `urlPath` in the configuration options. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R17) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R90-R96)

Implementation updates:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L146-R154): Modified the upload path to use `urlPath` if provided.
* [`src/uploader.ts`](diffhunk://#diff-a54e0d81fd9ec5deda5472cf3d8a59ebb033d8334639795f15018e9cfe14f5f9L17-R17): Updated the upload task creation to use `urlPath` for constructing the final URL. [[1]](diffhunk://#diff-a54e0d81fd9ec5deda5472cf3d8a59ebb033d8334639795f15018e9cfe14f5f9L17-R17) [[2]](diffhunk://#diff-a54e0d81fd9ec5deda5472cf3d8a59ebb033d8334639795f15018e9cfe14f5f9R73) [[3]](diffhunk://#diff-a54e0d81fd9ec5deda5472cf3d8a59ebb033d8334639795f15018e9cfe14f5f9L118-R119)