### PR TITLE
feat: support range-based placeholder syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ picgo set uploader s3
 | `{sha1}` | 图片 SHA1 |
 | `{sha256}` | 图片 SHA256 |
 
+对于 MD5、SHA1、SHA256，支持这几种截断方式：
+
+- `{sha256:2}`：从第三个字符开始，例如 `abcd -> cd`
+- `{sha256:2,4}`：从第三个字符开始，截取长度为4，例如 `abcdefgh`
+
 ---
 
 #### 自定义输出 URL 模板 (`outputURLPattern`)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "type": "commonjs",
   "homepage": "https://github.com/wayjam/picgo-plugin-s3",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "build": "tsc -p .",
     "dev": "tsc -w -p .",
     "pub": "rm -rf dist/* && npm build && npm publish",
@@ -29,16 +30,18 @@
   "author": "WayJam So",
   "license": "MIT",
   "devDependencies": {
-    "@types/mime": "^3.0.4",
     "@eslint/js": "^9.16.0",
+    "@types/mime": "^3.0.4",
     "@types/node": "^22.10.1",
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "@typescript-eslint/parser": "^8.17.0",
+    "@vitest/ui": "^4.0.18",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.4.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "~3.729.0",

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { FileNameGenerator } from '../utils'
+import { IImgInfo } from 'picgo'
+
+describe('FileNameGenerator.format', () => {
+  it('should format path with sha256 range patterns: screenshots/{sha256:0,2}/{sha256:2,2}/{sha256}.{extName}', () => {
+    // Create a mock IImgInfo with a known buffer
+    const mockBuffer = Buffer.from('test image content')
+    const mockInfo: IImgInfo = {
+      fileName: 'test.png',
+      extname: '.png',
+      buffer: mockBuffer,
+      imgSize: {
+        width: 100,
+        height: 100,
+      },
+    }
+
+    const generator = new FileNameGenerator(mockInfo)
+    
+    // Calculate expected sha256 hash
+    const expectedSha256 = generator.sha256()
+    
+    // Test the complete pattern with multiple pattern types in one string
+    const pattern = 'screenshots/{sha256:0,2}/{sha256:2,2}/{sha256}.{extName}'
+    const result = generator.format(pattern)
+    
+    // Expected result breakdown:
+    // {sha256:0,2} -> first 2 characters starting at position 0
+    // {sha256:2,2} -> 2 characters starting at position 2
+    // {sha256} -> full sha256 hash
+    // {extName} -> 'png' (without dot)
+    const expected = `screenshots/${expectedSha256.substring(0, 2)}/${expectedSha256.substring(2, 4)}/${expectedSha256}.png`
+    
+    expect(result).toBe(expected)
+  })
+
+  it('should handle multiple different range patterns correctly', () => {
+    const mockBuffer = Buffer.from('another test content')
+    const mockInfo: IImgInfo = {
+      fileName: 'image.jpg',
+      extname: '.jpg',
+      buffer: mockBuffer,
+      imgSize: {
+        width: 200,
+        height: 200,
+      },
+    }
+
+    const generator = new FileNameGenerator(mockInfo)
+    const sha256 = generator.sha256()
+    
+    // Test with different range combinations
+    const pattern = '{sha256:0,4}/{sha256:4,4}/{sha256:8,8}.{extName}'
+    const result = generator.format(pattern)
+    
+    const expected = `${sha256.substring(0, 4)}/${sha256.substring(4, 8)}/${sha256.substring(8, 16)}.jpg`
+    
+    expect(result).toBe(expected)
+  })
+
+  it('should handle truncate pattern {sha256:10}', () => {
+    const mockBuffer = Buffer.from('truncate test')
+    const mockInfo: IImgInfo = {
+      fileName: 'test.png',
+      extname: '.png',
+      buffer: mockBuffer,
+      imgSize: {
+        width: 100,
+        height: 100,
+      },
+    }
+
+    const generator = new FileNameGenerator(mockInfo)
+    const sha256 = generator.sha256()
+    
+    const pattern = '{sha256:10}.{extName}'
+    const result = generator.format(pattern)
+    
+    const expected = `${sha256.substring(0, 10)}.png`
+    
+    expect(result).toBe(expected)
+  })
+
+  it('should handle simple pattern without range', () => {
+    const mockBuffer = Buffer.from('simple test')
+    const mockInfo: IImgInfo = {
+      fileName: 'test.png',
+      extname: '.png',
+      buffer: mockBuffer,
+      imgSize: {
+        width: 100,
+        height: 100,
+      },
+    }
+
+    const generator = new FileNameGenerator(mockInfo)
+    const sha256 = generator.sha256()
+    
+    const pattern = '{sha256}.{extName}'
+    const result = generator.format(pattern)
+    
+    const expected = `${sha256}.png`
+    
+    expect(result).toBe(expected)
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,9 +157,17 @@ export class FileNameGenerator extends Generateor {
     return Object.entries(formatters).reduce(
       (result, [key, formatter]) => {
         const simplePattern = new RegExp(`{${key}}`, 'g')
+        const rangePattern = new RegExp(`{${key}:(\\d+),(\\d+)}`, 'g')
         const truncatePattern = new RegExp(`{${key}:(\\d+)}`, 'g')
 
-        if (truncatePattern.test(result)) {
+        if (rangePattern.test(result)) {
+          result = result.replace(rangePattern, (match, start, length) => {
+            const value = formatter()
+            const startPos = parseInt(start, 10)
+            const subLength = parseInt(length, 10)
+            return value.substring(startPos, startPos + subLength)
+          })
+        } else if (truncatePattern.test(result)) {
           result = result.replace(truncatePattern, (match, length) => {
             const value = formatter()
             const truncateLength = parseInt(length, 10)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,26 +156,28 @@ export class FileNameGenerator extends Generateor {
 
     return Object.entries(formatters).reduce(
       (result, [key, formatter]) => {
-        const simplePattern = new RegExp(`{${key}}`, 'g')
         const rangePattern = new RegExp(`{${key}:(\\d+),(\\d+)}`, 'g')
         const truncatePattern = new RegExp(`{${key}:(\\d+)}`, 'g')
+        const simplePattern = new RegExp(`{${key}}`, 'g')
 
-        if (rangePattern.test(result)) {
-          result = result.replace(rangePattern, (match, start, length) => {
-            const value = formatter()
-            const startPos = parseInt(start, 10)
-            const subLength = parseInt(length, 10)
-            return value.substring(startPos, startPos + subLength)
-          })
-        } else if (truncatePattern.test(result)) {
-          result = result.replace(truncatePattern, (match, length) => {
-            const value = formatter()
-            const truncateLength = parseInt(length, 10)
-            return value.substring(0, truncateLength)
-          })
-        } else {
-          result = result.replace(simplePattern, formatter())
-        }
+        // Replace range patterns: {key:start,length}
+        result = result.replace(rangePattern, (match, start, length) => {
+          const value = formatter()
+          const startPos = parseInt(start, 10)
+          const subLength = parseInt(length, 10)
+          return value.substring(startPos, startPos + subLength)
+        })
+
+        // Replace truncate patterns: {key:length}
+        result = result.replace(truncatePattern, (match, length) => {
+          const value = formatter()
+          const truncateLength = parseInt(length, 10)
+          return value.substring(0, truncateLength)
+        })
+
+        // Replace simple patterns: {key}
+        result = result.replace(simplePattern, formatter())
+
         return result
       },
       super.format(s)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
   "include": [
     "./src/**/*"
   ],
-  "exclude": [ "node_modules", "dist"]
+  "exclude": [ "node_modules", "dist", "**/*.spec.ts", "**/__tests__"]
 }


### PR DESCRIPTION
Add support for {placeholder:start,length} syntax to extract substring from specific position. Example: {sha256:1,2} extracts 2 characters starting from position 1.

Add unit tests for FileNameGenerator.format()

Add vitest and tests covering range, truncate, and simple pattern matching.
support mixed patterns like {sha256:0,2}/{sha256:2,2}/{sha256}.
